### PR TITLE
Release v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-redsync/redsync/v4 v4.14.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gofiber/contrib/fiberzap/v2 v2.1.6
-	github.com/gofiber/fiber/v2 v2.52.11
+	github.com/gofiber/fiber/v2 v2.52.12
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/google/wire v0.7.0
 	github.com/hashicorp/consul/api v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gofiber/contrib/fiberzap/v2 v2.1.6 h1:8aMBaO7jAB4w9o2uGC1S3ieKPxg8vfJ7t1aipq2pudg=
 github.com/gofiber/contrib/fiberzap/v2 v2.1.6/go.mod h1:sGrPV2XzRrI6aJQOmORr5rdk4vXLR630Oc/REtMmCYs=
-github.com/gofiber/fiber/v2 v2.52.11 h1:5f4yzKLcBcF8ha1GQTWB+mpblWz3Vz6nSAbTL31HkWs=
-github.com/gofiber/fiber/v2 v2.52.11/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
+github.com/gofiber/fiber/v2 v2.52.12 h1:0LdToKclcPOj8PktUdIKo9BUohjjwfnQl42Dhw8/WUw=
+github.com/gofiber/fiber/v2 v2.52.12/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=

--- a/internal/interfaces/rest/handler/version.go
+++ b/internal/interfaces/rest/handler/version.go
@@ -54,41 +54,73 @@ type tuple struct {
 	ip      string
 }
 
+const (
+	hllKeyPrefix    = "hll:resource:"
+	activeSetPrefix = "active:resources:"
+	viewKeyPrefix   = "sort:resources:request:"
+	keyTTL          = time.Hour * 24 * 9
+	syncInterval    = 15 * time.Minute
+)
+
 func (h *VersionHandler) getCollector() func(string, string, string) {
 	rdb := h.versionLogic.GetRedisClient()
 
 	var ch = make(chan tuple, 1000)
 
 	go func() {
-		var ctx = context.Background()
+		var (
+			ctx           = context.Background()
+			expiredHLL    = make(map[string]struct{})
+			expiredActive = make(map[string]struct{})
+			lastDate      string
+		)
 		for val := range ch {
 			date := time.Now().Format("20060102")
+			if date != lastDate {
+				clear(expiredHLL)
+				clear(expiredActive)
+				lastDate = date
+			}
 
-			hllKey := "hll:resource:" + val.rid + ":" + date
-			added, err := rdb.PFAdd(ctx, hllKey, val.ip).Result()
-			if err != nil {
+			hllKey := hllKeyPrefix + val.rid + ":" + date
+			if _, err := rdb.PFAdd(ctx, hllKey, val.ip).Result(); err != nil {
 				h.logger.Warn("collector PFAdd error", zap.String("rid", val.rid), zap.Error(err))
 				continue
 			}
-			if added == 0 {
-				continue
+			if _, ok := expiredHLL[val.rid]; !ok {
+				rdb.Expire(ctx, hllKey, keyTTL)
+				expiredHLL[val.rid] = struct{}{}
 			}
 
-			viewKey := "sort:resources:request:" + date
-			result, err := rdb.ZAddArgsIncr(ctx, viewKey, redis.ZAddArgs{
-				Members: []redis.Z{
-					{
-						Score:  1,
-						Member: val.rid,
-					},
-				},
-			}).Result()
+			activeKey := activeSetPrefix + date
+			added, err := rdb.SAdd(ctx, activeKey, val.rid).Result()
 			if err != nil {
-				h.logger.Warn("collector ZAddArgsIncr error", zap.String("rid", val.rid), zap.Error(err))
-			} else if result == 1 {
-				rdb.Expire(ctx, viewKey, time.Hour*24*9)
+				h.logger.Warn("collector SAdd error", zap.String("rid", val.rid), zap.Error(err))
+				continue
 			}
-			rdb.Expire(ctx, hllKey, time.Hour*24*9)
+			if added > 0 {
+				if _, ok := expiredActive[date]; !ok {
+					rdb.Expire(ctx, activeKey, keyTTL)
+					expiredActive[date] = struct{}{}
+				}
+			}
+		}
+	}()
+
+	go func() {
+		var (
+			ctx      = context.Background()
+			ticker   = time.NewTicker(syncInterval)
+			lastDate = time.Now().Format("20060102")
+		)
+		defer ticker.Stop()
+		for range ticker.C {
+			currentDate := time.Now().Format("20060102")
+			if currentDate != lastDate {
+				h.doSyncDAU(ctx, lastDate)
+				lastDate = currentDate
+			}
+			h.doSyncDAU(ctx, currentDate)
 		}
 	}()
 
@@ -103,7 +135,36 @@ func (h *VersionHandler) getCollector() func(string, string, string) {
 			ip:      strings.Clone(ip),
 		}
 	}
+}
 
+func (h *VersionHandler) doSyncDAU(ctx context.Context, date string) {
+	rdb := h.versionLogic.GetRedisClient()
+	activeKey := activeSetPrefix + date
+	rids, err := rdb.SMembers(ctx, activeKey).Result()
+	if err != nil {
+		h.logger.Warn("doSyncDAU SMembers error", zap.String("date", date), zap.Error(err))
+		return
+	}
+	if len(rids) == 0 {
+		return
+	}
+
+	viewKey := viewKeyPrefix + date
+	for _, rid := range rids {
+		hllKey := hllKeyPrefix + rid + ":" + date
+		count, err := rdb.PFCount(ctx, hllKey).Result()
+		if err != nil {
+			h.logger.Warn("doSyncDAU PFCount error", zap.String("rid", rid), zap.Error(err))
+			continue
+		}
+		if _, err := rdb.ZAdd(ctx, viewKey, redis.Z{
+			Score:  float64(count),
+			Member: rid,
+		}).Result(); err != nil {
+			h.logger.Warn("doSyncDAU ZAdd error", zap.String("rid", rid), zap.Error(err))
+		}
+	}
+	rdb.Expire(ctx, viewKey, keyTTL)
 }
 
 func (h *VersionHandler) Register(r fiber.Router) {


### PR DESCRIPTION
## Summary by Sourcery

使用 Redis 优化每日活跃使用量收集机制，并定期同步聚合计数，同时更新一个框架依赖。

新特性：
- 引入定期同步机制，将每个资源的 HyperLogLog 键中的每日活跃使用量计数聚合到有序集合中。

增强：
- 使用 Redis 集合按日跟踪活跃资源，以支持批量 DAU 聚合，而不是在每次请求时更新分数。
- 将资源使用跟踪相关的 Redis 键前缀、TTL 和同步间隔配置进行集中管理。

构建：
- 将 github.com/gofiber/fiber/v2 依赖升级到 v2.52.12。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine daily active usage collection using Redis and periodically synchronize aggregated counts while updating a framework dependency.

New Features:
- Introduce periodic synchronization of daily active usage counts from per-resource HyperLogLog keys into sorted sets.

Enhancements:
- Track active resources per day in Redis sets to enable batched DAU aggregation instead of per-request score updates.
- Centralize Redis key prefixes, TTL, and sync interval configuration for resource usage tracking.

Build:
- Bump github.com/gofiber/fiber/v2 dependency to v2.52.12.

</details>