### PR TITLE
Release v1.5.0

### DIFF
--- a/internal/oss/model.go
+++ b/internal/oss/model.go
@@ -2,7 +2,7 @@ package oss
 
 const (
 	expireTime = int64(3600)
-	bodyLimit  = 1000 * 1024 * 1024
+	bodyLimit  = 1600 * 1024 * 1024
 )
 
 type ConfigStruct struct {


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 将 OSS 请求正文大小限制从 1 GB 提升到 1.6 GB，以允许更大的负载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Raise OSS request body size limit from 1 GB to 1.6 GB to allow larger payloads.

</details>