### PR TITLE
feat: webhook 限频：每rid 2min一次

### DIFF
--- a/internal/logic/misc/misc.go
+++ b/internal/logic/misc/misc.go
@@ -34,6 +34,8 @@ const (
 	ProcessFlag = "1"
 )
 
+const WebhookNotifyThrottlePrefix = "webhook:notify:throttle"
+
 // StatusPollingPrefix status polling
 const StatusPollingPrefix = "status:polling"
 

--- a/internal/logic/version.go
+++ b/internal/logic/version.go
@@ -517,6 +517,15 @@ func (l *VersionLogic) doWebhookNotify(resourceId, versionName, channel, os, arc
 		return
 	}
 
+	throttleKey := misc.WebhookNotifyThrottlePrefix + ":" + resourceId
+	ok, err := l.rdb.SetNX(context.Background(), throttleKey, 1, 2*time.Minute).Result()
+	if err != nil {
+		l.logger.Warn("Failed to check webhook throttle", zap.Error(err))
+	}
+	if !ok {
+		return
+	}
+
 	buf, e := sonic.Marshal(map[string]string{
 		"resource_id":  resourceId,
 		"version_name": versionName,


### PR DESCRIPTION
## Summary by Sourcery

为 webhook 通知添加节流机制，以限制每个资源 ID 的发送频率。

Enhancements:
- 为 webhook 通知引入基于 Redis 的节流机制，使每个资源 ID 至多每两分钟发送一次通知。
- 为 webhook 通知节流定义一个专用的 Redis 键前缀常量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add throttling to webhook notifications to limit how frequently they are sent per resource ID.

Enhancements:
- Introduce a Redis-based throttle for webhook notifications, allowing at most one notification per resource ID every two minutes.
- Define a dedicated Redis key prefix constant for webhook notification throttling.

</details>