### PR TITLE
feat: open-access cdk, identical response but not downloadable

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -30,6 +30,19 @@ auth:
   uploader_validation_url: "https://uploader.validation.example"
   cdk_validation_url: "https://cdk.validation.example"
   download_validation_url: "https://download.validation.example"
+  # open-access cdk: same response as a normal cdk, but the url is not downloadable
+  public_cdk:
+    enabled: true
+    # 2100-01-01, keeps the documented sample stable
+    expired_time: 4102416000
+    keys:
+      # official doc sample / sdk integration
+      - key: "MIRRORC-PUBLIC-TRIAL-0001"
+        resources: [ "*" ]
+      # MAA only
+      - key: "MIRRORC-PUBLIC-MAA-0002"
+        resources: [ "MAA", "MFAAvalonia" ]
+        expired_time: 1790000000
 
 oss:
   endpoint: "https://oss-cn-hangzhou.aliyuncs.com"

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -65,11 +65,24 @@ type (
 	}
 
 	AuthConfig struct {
-		SignSecret            string `mapstructure:"sign_secret"`
-		PrivateKey            string `mapstructure:"private_key"`
-		UploaderValidationURL string `mapstructure:"uploader_validation_url"`
-		CDKValidationURL      string `mapstructure:"cdk_validation_url"`
-		DownloadValidationURL string `mapstructure:"download_validation_url"`
+		SignSecret            string          `mapstructure:"sign_secret"`
+		PrivateKey            string          `mapstructure:"private_key"`
+		UploaderValidationURL string          `mapstructure:"uploader_validation_url"`
+		CDKValidationURL      string          `mapstructure:"cdk_validation_url"`
+		DownloadValidationURL string          `mapstructure:"download_validation_url"`
+		PublicCDK             PublicCDKConfig `mapstructure:"public_cdk"`
+	}
+
+	PublicCDKConfig struct {
+		Enabled     bool             `mapstructure:"enabled"`
+		ExpiredTime int64            `mapstructure:"expired_time"`
+		Keys        []PublicCDKEntry `mapstructure:"keys"`
+	}
+
+	PublicCDKEntry struct {
+		Key         string   `mapstructure:"key"`
+		Resources   []string `mapstructure:"resources"` // empty or ["*"] means every resource
+		ExpiredTime int64    `mapstructure:"expired_time"`
 	}
 	OSSConfig struct {
 		ExternalHost string `mapstructure:"external_host"`

--- a/internal/interfaces/rest/handler/version.go
+++ b/internal/interfaces/rest/handler/version.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/MirrorChyan/resource-backend/internal/logic/misc"
 	"github.com/MirrorChyan/resource-backend/internal/middleware"
 	"github.com/MirrorChyan/resource-backend/internal/pkg/errs"
+	"github.com/MirrorChyan/resource-backend/internal/pkg/publiccdk"
 	"github.com/MirrorChyan/resource-backend/internal/pkg/validator"
 	"github.com/MirrorChyan/resource-backend/internal/pkg/vercomp"
 	"github.com/bytedance/sonic"
@@ -408,13 +409,25 @@ func (h *VersionHandler) GetLatest(c *fiber.Ctx) error {
 		return c.JSON(resp)
 	}
 
-	ts, err := h.doValidateCDK(param, resourceId, ip)
-	if err != nil {
-		var biz *errs.Error
-		if errors.As(err, &biz) {
-			return biz.WithDetails(data)
+	var (
+		ts   int64
+		mode string
+	)
+	if exp, ok := publiccdk.Match(cdk, resourceId); ok {
+		ts, mode = exp, CDKModePublic
+		h.logger.Info("public cdk hit",
+			zap.String("rid", resourceId),
+			zap.String("ip", ip),
+		)
+	} else {
+		ts, err = h.doValidateCDK(param, resourceId, ip)
+		if err != nil {
+			var biz *errs.Error
+			if errors.As(err, &biz) {
+				return biz.WithDetails(data)
+			}
+			return err
 		}
-		return err
 	}
 
 	if latest.VersionName == currentVersion {
@@ -441,6 +454,7 @@ func (h *VersionHandler) GetLatest(c *fiber.Ctx) error {
 		Version:  latest.VersionName,
 		Filesize: result.Filesize,
 		RelPath:  result.RelPath,
+		Mode:     mode,
 	})
 	if err != nil {
 		return err

--- a/internal/logic/misc/misc.go
+++ b/internal/logic/misc/misc.go
@@ -18,6 +18,13 @@ const (
 	DispensePrefix = "dispense"
 )
 
+// cdk mode carried by DistributeInfo
+const (
+	// CDKModeNormal keeps the zero value so the legacy payload in redis stays valid
+	CDKModeNormal = ""
+	CDKModePublic = "public"
+)
+
 const (
 	ContentTypeZip   = "application/zip"
 	ContentTypeTarGz = "application/x-gtar"
@@ -90,6 +97,13 @@ var (
 	NotAllowedFileTypeError = errs.NewUnchecked("not allowed file type")
 
 	ResourceLimitError = errs.NewUnchecked("your cdkey has reached the most downloads today").WithHttpCode(fiber.StatusForbidden)
+
+	PublicCDKNotDownloadableError = errs.New(
+		errs.BizCodePublicCDKNotDownloadable,
+		fiber.StatusForbidden,
+		"this is an open-access cdk for evaluation only, please get a valid cdk to download",
+		nil,
+	)
 )
 
 var (

--- a/internal/logic/version.go
+++ b/internal/logic/version.go
@@ -937,6 +937,15 @@ func (l *VersionLogic) GetDistributeLocation(ctx context.Context, rk string) (st
 		return "", err
 	}
 
+	// an open-access cdk never reaches the download validation service
+	if info.Mode == misc.CDKModePublic {
+		l.logger.Info("public cdk download rejected",
+			zap.String("rid", info.Resource),
+			zap.String("ip", info.IP),
+		)
+		return "", misc.PublicCDKNotDownloadableError
+	}
+
 	body, err := sonic.Marshal(DownloadValidateCDKRequest{
 		CDK:      info.CDK,
 		Resource: info.Resource,

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -49,6 +49,7 @@ type DistributeInfo struct {
 	Version  string `json:"version,omitempty"`
 	Filesize int64  `json:"filesize,omitempty"`
 	RelPath  string `json:"rel_path"`
+	Mode     string `json:"mode,omitempty"`
 }
 
 type FileDetectResult struct {

--- a/internal/pkg/errs/bizcode.go
+++ b/internal/pkg/errs/bizcode.go
@@ -11,4 +11,5 @@ const (
 	BizCodeResourceVersionNameConflict      = 8006
 	BizCodeResourceVersionStorageProcessing = 8007
 	BizResourceVersionNameUnparsable        = 8008
+	BizCodePublicCDKNotDownloadable         = 8009
 )

--- a/internal/pkg/publiccdk/publiccdk.go
+++ b/internal/pkg/publiccdk/publiccdk.go
@@ -1,0 +1,100 @@
+// Package publiccdk holds the open-access cdk whitelist.
+//
+// An open-access cdk is resolved locally instead of being sent to the upstream
+// validation service, so /latest answers it exactly like a paid one, but the
+// distribute info is marked and the download key is refused on redemption.
+package publiccdk
+
+import (
+	"cmp"
+	"sync/atomic"
+
+	"github.com/MirrorChyan/resource-backend/internal/config"
+	"go.uber.org/zap"
+)
+
+const listenKey = "auth.public_cdk"
+
+type entry struct {
+	all       bool
+	resources map[string]struct{}
+	expiredAt int64
+}
+
+type snapshot struct {
+	enabled bool
+	keys    map[string]*entry
+}
+
+var current atomic.Pointer[snapshot]
+
+func init() {
+	config.RegisterKeyListener(config.KeyListener{
+		Key: listenKey,
+		Listener: func(any) {
+			Reload()
+		},
+	})
+}
+
+// Reload rebuilds the whitelist from config.GConfig.
+//
+// The remote config listener only fires when the consul value actually changes,
+// so this must also be called once explicitly after config.InitGlobalConfig,
+// otherwise the standalone mode would always see an empty whitelist.
+func Reload() {
+	var (
+		conf = config.GConfig.Auth.PublicCDK
+		s    = &snapshot{
+			enabled: conf.Enabled,
+			keys:    make(map[string]*entry, len(conf.Keys)),
+		}
+	)
+
+	for _, k := range conf.Keys {
+		if k.Key == "" {
+			continue
+		}
+		e := &entry{
+			resources: make(map[string]struct{}, len(k.Resources)),
+			expiredAt: cmp.Or(k.ExpiredTime, conf.ExpiredTime),
+		}
+		if len(k.Resources) == 0 {
+			e.all = true
+		}
+		for _, r := range k.Resources {
+			if r == "*" {
+				e.all = true
+				continue
+			}
+			e.resources[r] = struct{}{}
+		}
+		s.keys[k.Key] = e
+	}
+
+	current.Store(s)
+
+	zap.L().Info("public cdk reloaded",
+		zap.Bool("enabled", s.enabled),
+		zap.Int("count", len(s.keys)),
+	)
+}
+
+// Match reports whether cdk is an open-access cdk of the given resource,
+// it returns the expired time exposed as cdk_expired_time when matched.
+func Match(cdk, rid string) (int64, bool) {
+	s := current.Load()
+	if s == nil || !s.enabled || cdk == "" {
+		return 0, false
+	}
+	e, ok := s.keys[cdk]
+	if !ok {
+		return 0, false
+	}
+	if !e.all {
+		if _, ok := e.resources[rid]; !ok {
+			return 0, false
+		}
+	}
+	return e.expiredAt, true
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MirrorChyan/resource-backend/internal/ent"
 	_ "github.com/MirrorChyan/resource-backend/internal/pkg/banner"
 	"github.com/MirrorChyan/resource-backend/internal/pkg/logger"
+	"github.com/MirrorChyan/resource-backend/internal/pkg/publiccdk"
 	"github.com/MirrorChyan/resource-backend/internal/pkg/vercomp"
 	"github.com/MirrorChyan/resource-backend/internal/tasks"
 	"github.com/MirrorChyan/resource-backend/internal/wire"
@@ -72,4 +73,5 @@ func setUpConfigAndLog() {
 	// in the full life cycle
 	config.InitGlobalConfig()
 	zap.ReplaceGlobals(logger.New())
+	publiccdk.Reload()
 }


### PR DESCRIPTION
## Summary by Sourcery

引入对开放访问（公共）CDK 的支持，这类 CDK 可以收到正常的版本响应，但会被禁止下载构件（artifacts）。

New Features:
- 添加公共 CDK 白名单配置和内存快照，并支持从全局配置中动态重载。
- 在分发（distribute）元数据中暴露 CDK 模式，以便在 API 响应中区分普通 CDK 和公共 CDK。

Enhancements:
- 为公共 CDK 在下载流程中提供短路处理，返回明确的业务错误并进行结构化日志记录。
- 扩展认证（auth）和错误码模型，以支持公共 CDK 的处理和业务码上报。

Documentation:
- 在默认配置 YAML 中记录示例公共 CDK 密钥和相关配置，包括其仅用于评估（evaluation-only）的预期行为说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce support for open-access (public) CDKs that receive normal version responses but are prevented from downloading artifacts.

New Features:
- Add public CDK whitelist configuration and in-memory snapshot with dynamic reload from global config.
- Expose CDK mode in distribute metadata to distinguish normal and public CDKs in API responses.

Enhancements:
- Short-circuit download flow for public CDKs with a clear business error and structured logging.
- Extend auth and error code models to support public CDK handling and business code reporting.

Documentation:
- Document sample public CDK keys and configuration in the default config YAML, including intended evaluation-only behavior.

</details>